### PR TITLE
10 https

### DIFF
--- a/install_ssl_apache.sh
+++ b/install_ssl_apache.sh
@@ -8,30 +8,27 @@ RESET="\e[0m"
 
 echo -e "${GREEN}🔹 Activation de HTTPS sur Apache (Debian) 🔹${RESET}"
 
-# Demander le nom de domaine
-read -p "🔹 Entrez le nom de domaine (ex: monsite.com) : " DOMAIN
+# Le nom de domaine est prédéfini
+DOMAIN="site.unionrolistes.fr"
 
-if [[ -z "$DOMAIN" ]]; then
-    echo -e "${RED}❌ Aucun domaine saisi. Script annulé.${RESET}"
-    exit 1
-fi
+echo -e "${YELLOW}📌 Nom de domaine configuré : $DOMAIN${RESET}"
 
 # Vérifier et installer Certbot si absent
 if ! command -v certbot &> /dev/null; then
     echo -e "${YELLOW}🛠️ Installation de Certbot...${RESET}"
-    apt update && apt install -y certbot python3-certbot-apache
+    sudo apt update && sudo apt install -y certbot python3-certbot-apache
 else
     echo -e "${GREEN}✅ Certbot est déjà installé.${RESET}"
 fi
 
 # Activer les modules Apache nécessaires
 echo -e "${YELLOW}📌 Activation des modules Apache SSL et Rewrite...${RESET}"
-a2enmod ssl rewrite
-systemctl reload apache2
+sudo a2enmod ssl rewrite
+sudo systemctl reload apache2
 
 # Générer le certificat SSL avec Certbot
 echo -e "${YELLOW}🔹 Obtention du certificat SSL pour $DOMAIN...${RESET}"
-certbot --apache --redirect -d "$DOMAIN"
+sudo certbot --apache --redirect -d "$DOMAIN"
 
 if [[ $? -ne 0 ]]; then
     echo -e "${RED}❌ Échec de la génération du certificat. Vérifiez que votre domaine pointe bien vers ce serveur.${RESET}"
@@ -42,18 +39,28 @@ echo -e "${GREEN}✅ Certificat SSL installé avec succès !${RESET}"
 
 # Vérifier si le renouvellement automatique est actif
 echo -e "${YELLOW}🔹 Vérification du renouvellement automatique...${RESET}"
-if systemctl list-timers | grep -q certbot; then
+if sudo systemctl list-timers | grep -q certbot; then
     echo -e "${GREEN}✅ Le renouvellement automatique du certificat SSL est actif.${RESET}"
 else
     echo -e "${RED}❌ Le renouvellement automatique n'est pas activé ! Ajoutons-le...${RESET}"
-    systemctl enable certbot.timer
-    systemctl start certbot.timer
+    sudo systemctl enable certbot.timer
+    sudo systemctl start certbot.timer
     echo -e "${GREEN}✅ Le renouvellement automatique est maintenant activé.${RESET}"
+fi
+
+# Tester le renouvellement automatique (dry-run)
+echo -e "${YELLOW}🔹 Test du renouvellement automatique du certificat (dry run)...${RESET}"
+sudo certbot renew --dry-run
+
+if [[ $? -eq 0 ]]; then
+    echo -e "${GREEN}✅ Le test de renouvellement automatique a réussi !${RESET}"
+else
+    echo -e "${RED}❌ Échec du test de renouvellement automatique. Vérifiez la configuration.${RESET}"
 fi
 
 # Redémarrer Apache pour appliquer les changements
 echo -e "${YELLOW}🔄 Redémarrage d'Apache...${RESET}"
-systemctl restart apache2
+sudo systemctl restart apache2
 
 echo -e "${GREEN}🎉 HTTPS activé et renouvellement automatique configuré pour $DOMAIN !${RESET}"
 echo -e "${GREEN}🔗 Testez votre site en HTTPS : https://$DOMAIN ${RESET}"

--- a/install_ssl_apache.sh
+++ b/install_ssl_apache.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Définition des couleurs pour les messages
+GREEN="\e[32m"
+YELLOW="\e[33m"
+RED="\e[31m"
+RESET="\e[0m"
+
+echo -e "${GREEN}🔹 Activation de HTTPS sur Apache (Debian) 🔹${RESET}"
+
+# Demander le nom de domaine
+read -p "🔹 Entrez le nom de domaine (ex: monsite.com) : " DOMAIN
+
+if [[ -z "$DOMAIN" ]]; then
+    echo -e "${RED}❌ Aucun domaine saisi. Script annulé.${RESET}"
+    exit 1
+fi
+
+# Vérifier et installer Certbot si absent
+if ! command -v certbot &> /dev/null; then
+    echo -e "${YELLOW}🛠️ Installation de Certbot...${RESET}"
+    apt update && apt install -y certbot python3-certbot-apache
+else
+    echo -e "${GREEN}✅ Certbot est déjà installé.${RESET}"
+fi
+
+# Activer les modules Apache nécessaires
+echo -e "${YELLOW}📌 Activation des modules Apache SSL et Rewrite...${RESET}"
+a2enmod ssl rewrite
+systemctl reload apache2
+
+# Générer le certificat SSL avec Certbot
+echo -e "${YELLOW}🔹 Obtention du certificat SSL pour $DOMAIN...${RESET}"
+certbot --apache --redirect -d "$DOMAIN"
+
+if [[ $? -ne 0 ]]; then
+    echo -e "${RED}❌ Échec de la génération du certificat. Vérifiez que votre domaine pointe bien vers ce serveur.${RESET}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Certificat SSL installé avec succès !${RESET}"
+
+# Vérifier si le renouvellement automatique est actif
+echo -e "${YELLOW}🔹 Vérification du renouvellement automatique...${RESET}"
+if systemctl list-timers | grep -q certbot; then
+    echo -e "${GREEN}✅ Le renouvellement automatique du certificat SSL est actif.${RESET}"
+else
+    echo -e "${RED}❌ Le renouvellement automatique n'est pas activé ! Ajoutons-le...${RESET}"
+    systemctl enable certbot.timer
+    systemctl start certbot.timer
+    echo -e "${GREEN}✅ Le renouvellement automatique est maintenant activé.${RESET}"
+fi
+
+# Redémarrer Apache pour appliquer les changements
+echo -e "${YELLOW}🔄 Redémarrage d'Apache...${RESET}"
+systemctl restart apache2
+
+echo -e "${GREEN}🎉 HTTPS activé et renouvellement automatique configuré pour $DOMAIN !${RESET}"
+echo -e "${GREEN}🔗 Testez votre site en HTTPS : https://$DOMAIN ${RESET}"

--- a/src/sites-available/300-UR_Site.conf
+++ b/src/sites-available/300-UR_Site.conf
@@ -8,6 +8,19 @@
         # However, you must set it for any further virtual host explicitly.
         ServerName site.unionrolistes.fr
         ServerAdmin webmaster@localhost
+
+        # Redirect HTTP to HTTPS
+        Redirect permanent / https://site.unionrolistes.fr/
+
+        ErrorLog ${APACHE_LOG_DIR}/Web_Site/error.log
+        CustomLog ${APACHE_LOG_DIR}/Web_Site/access.log combined
+</VirtualHost>
+
+<VirtualHost *:443>
+        # Enable SSL for secure connection
+        ServerName site.unionrolistes.fr
+        ServerAdmin webmaster@localhost
+
         DocumentRoot /var/www/html/Web_Site
         <Directory "/var/www/html/Web_Site/">
                 Options +Indexes +Includes +FollowSymLinks +MultiViews +ExecCGI
@@ -15,6 +28,11 @@
                 AllowOverride All
                 Require all granted
         </Directory>
+
+        # SSL Configuration
+        SSLEngine on
+        SSLCertificateFile /etc/letsencrypt/live/site.unionrolistes.fr/fullchain.pem
+        SSLCertificateKeyFile /etc/letsencrypt/live/site.unionrolistes.fr/privkey.pem
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
         # error, crit, alert, emerg.
@@ -25,12 +43,19 @@
         ErrorLog ${APACHE_LOG_DIR}/Web_Site/error.log
         CustomLog ${APACHE_LOG_DIR}/Web_Site/access.log combined
 
-        # For most configuration files from conf-available/, which are
-        # enabled or disabled at a global level, it is possible to
-        # include a line for only one particular virtual host. For example the
-        # following line enables the CGI configuration for this host only
-        # after it has been globally disabled with "a2disconf".
-        #Include conf-available/serve-cgi-bin.conf
+        # Enable HSTS (HTTP Strict Transport Security)
+        Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+
+        # Enable OCSP Stapling for better SSL performance
+        SSLUseStapling on
+        SSLStaplingCache "shmcb:/var/run/ocsp(128000)"
+
+        # Security headers
+        Header always set X-Frame-Options "DENY"
+        Header always set X-Content-Type-Options "nosniff"
+        Header always set Referrer-Policy "no-referrer-when-downgrade"
+        Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';"
+
 </VirtualHost>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Les changements:
- Ajout d'un script appeler install_ssl_apache.sh , il installer certbot qui permet d'automatiser l'obtention d'un certificat ssl grâce a Let's Encrypt, ensuite vérifie le renouvellement automatique et redémarre apache.

- Modifier le fichier 300-UR_Site.conf pour y ajouter une connexion sécurisée https avec un certificat SSL Let's Encrypt et redirige les tentative de connexion http en https.
 
Pour passer le site en HTTPS il faut donc mettre ajour le fichier "300-UR_Site.conf" situé dans "/etc/apache2/sites-available" ,
puis exécuter le script "install_ssl_apache.sh".
