### PR TITLE
Dockerise le site pour le déployer via Komodo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:8.4-apache
+
+COPY src/www/ /var/www/html/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  web:
+    build: .
+    image: web-site
+    container_name: web-site
+    restart: unless-stopped
+    ports:
+      - "8081:80"


### PR DESCRIPTION
## Contexte

Le site est actuellement servi directement par l'Apache système
(`/var/www/html/Web_Site`), en dehors de la portée de Komodo Periphery
(root limitée à `/etc/komodo`). Impossible de le gérer comme un Stack
Komodo (build/deploy/rollback depuis l'UI) sans le conteneuriser.

## Ce que fait cette PR

- `Dockerfile` : image `php:8.4-apache` (même version PHP que le serveur
  actuel), `COPY src/www/ /var/www/html/` — le site est un `index.php`
  autonome sans dépendance, pas de build step nécessaire
- `docker-compose.yml` : build + run sur le port `8081:80`

## Après merge

Le conteneur sera géré par Komodo (comme `milestone.unionrolistes.fr`), et
l'Apache système fera un simple reverse-proxy vers `localhost:8081` au lieu
de servir les fichiers directement — même pattern que le vhost `020-millestone.conf`.

## Testé

- [x] Build Docker local : OK
- [x] Smoke test : `HTTP 200`, titre de la page correct, contenu identique