### PR TITLE
chore: retire le port legacy 8081 (Traefik est l'unique point d'entrée)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     image: web-site
     container_name: web-site
     restart: unless-stopped
-    # Port encore publié pendant la préparation de la bascule Traefik :
-    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
-    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
-    ports:
-      - "8081:80"
     networks:
       - default
       - traefik-public


### PR DESCRIPTION
Closes #25

Le port était laissé intentionnellement publié pendant la préparation de la bascule Traefik (Apache en dépendait). Apache est maintenant entièrement retiré, Traefik gère tout le routage via labels — ce port n'est plus utile et n'était accessible que par contournement du firewall (bloqué depuis le 2026-07-15 par la chaîne DOCKER-USER).