### PR TITLE
fix: retire la ligne image: redondante (bloquait le déploiement Komodo)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   web:
     build: .
-    image: web-site
     container_name: web-site
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Closes #27

`docker compose pull` (lancé par Komodo avant le build) tentait de récupérer `web-site` depuis un registre au lieu de la construire localement — échec `pull access denied`, cette image n'a jamais été publiée. Retire la ligne `image:` redondante ; Compose nomme automatiquement l'image buildée, comme les 4 autres stacks backend.